### PR TITLE
Enclose meal header components in span elements

### DIFF
--- a/MMM-MealieMenu.njk
+++ b/MMM-MealieMenu.njk
@@ -18,7 +18,9 @@
       {% endif %}
       <div class="meal-info">
         <div class="meal-header">
-          {{ meal.date }}{{ config.dateMealSeperator }}{{ meal.meal }}
+          <span class="meal-date">{{ meal.date }}</span>
+          <span class="meal-separator">{{ config.dateMealSeperator }}</span>
+          <span class="meal-type">{{ meal.meal }}</span>
         </div>
         <div class="meal-name">
           {{ meal.name }}


### PR DESCRIPTION
I'd like to style the meal date differently than the meal name.  Enclosing the parts in span tags makes this much easier to do.

If there's a different way you'd prefer this to be accomplished, just let me know.