### PR TITLE
feat: add message when meal plan is empty

### DIFF
--- a/MMM-MealieMenu.css
+++ b/MMM-MealieMenu.css
@@ -81,3 +81,7 @@
   color: #fff;
   font-size: calc(var(--font-size-medium) - 0.3rem);
 }
+
+.MMM-MealieMenu .meal-empty {
+  text-align: center;
+}

--- a/MMM-MealieMenu.js
+++ b/MMM-MealieMenu.js
@@ -137,7 +137,8 @@ Module.register("MMM-MealieMenu", {
   getTemplateData () {
     return {
       phrases: {
-        loading: this.translate("LOADING")
+        loading: this.translate("LOADING"),
+        emptyMealPlan: this.translate("MEALIE_EMPTY_MEALPLAN")
       },
       hasError: Boolean(this.error),
       error: this.error,

--- a/MMM-MealieMenu.njk
+++ b/MMM-MealieMenu.njk
@@ -33,6 +33,12 @@
       </div>
     </div>
     {% endfor %}
+
+    {% if menu.meals | length == 0 %}
+    <div class="meal-empty">
+      {{ phrases.emptyMealPlan | safe }}
+    </div>
+    {% endif %}
   </div>
 
   <div class="meta-timestamp" id="{{ moduleTimestampIdPrefix + identifier }}" data-timestamp="{{ timestamp }}">

--- a/translations/en.json
+++ b/translations/en.json
@@ -9,6 +9,7 @@
   "FETCH_ERROR": "Fetch Error: There was an error fetching data from Mealie.",
   "MEALIE_SUSPEND": "Function suspend - module: {name} with identifier: {identifier}",
   "MEALIE_RESUME": "Function resume - module: {name} with identifier: {identifier}",
+  "MEALIE_EMPTY_MEALPLAN": "There are no meals planned.",
   "MEAL_TYPES": {
     "breakfast": "Breakfast",
     "lunch": "Lunch",


### PR DESCRIPTION
This PR adds a message when there are no meals currently planned.  We don't typically do meal planning for the weekends (just weekdays) so having an empty box on our screen was not ideal.

I ran `npm run lint:fix`, and I believe the message conforms to the Angular commit message guidelines.

Let me know if there's anything else you'd like me to consider!


